### PR TITLE
Twitter name is now updated via a template instead of via a prefix.

### DIFF
--- a/app/views/setup.twig
+++ b/app/views/setup.twig
@@ -10,8 +10,11 @@ and remove this application from your account.</div>
 <form method="POST">
   <label for="lastfmname">Last.fm Username</label>
   <input type="text" id="lastfmname" ="lastfmname" value="{{ setting.lastfmname }}" placeholder="Last FM Username">
-  <label for="twittertext">The first part of the username when playing music</label>
-  <input type="text" id="twittertext"  name="twittertext" value="{{ setting.twittertext }}" placeholder="Text before the songinformation">
+  <label for="twittertext">
+    The template to use for your twitter name.<br>
+    Ex: <span class="code">"Doug 🎵 {{'{{'}}artist{{'}}'}} - {{'{{'}}track{{'}}'}}"</span>
+  </label>
+  <input type="text" id="twittertext"  name="twittertext" value="{{ setting.twittertext }}" placeholder="Twitter Name Template">
 
 
   {#<input type="checkbox" name="goBackToDefault" value="goBackToDefault"> If 30 minutes have passed after changing username go back to default Twittername<br>

--- a/cronjobRunner.php
+++ b/cronjobRunner.php
@@ -34,13 +34,15 @@
         $artist = $artistData->{'#text'};
         $track = $track->name;
 
-        return "$artist — $track";
+        return array($artist, $track);
   }
 
   $settingsItems = Settings::find_many();
   if(count($settingsItems) > 9000) {
     die('too many people!!!');
   }
+
+  $twig = new \Twig_Environment(new \Twig_Loader_String());
 
   foreach ($settingsItems as $key => $setting) {
     sleep(0.01); // safety net so we never hit the twitter api to hard.
@@ -57,9 +59,13 @@
     $url = 'https://api.twitter.com/1.1/account/update_profile.json';
     $requestMethod = 'POST';
 
-    $songname = getLastPlayedSong($settings["lastfm_username"], $settings["lastfm_apikey"]);
-
-    $newTwitterName = $setting->twittertext . ' ' . $songname;
+    list($artist, $track) = getLastPlayedSong($settings["lastfm_username"], $settings["lastfm_apikey"]);
+    $template = $setting->twittertext;
+    $templateParameters = array(
+      'artist' => $artist,
+      'track' => $track,
+    );
+    $newTwitterName = $twig->render($template, $templateParameters);
 
     if($user->lastTwitterName != $newTwitterName) {
 

--- a/css/style.css
+++ b/css/style.css
@@ -24,3 +24,11 @@ form * {
   margin: 2rem 0 ;
   font-size: 2rem;
 }
+form input[type="text"] {
+  width: 100%;
+}
+form span.code {
+  display: inline;
+  font-family: "Courier New", Courier, "Lucida Sans Typewriter", "Lucida Typewriter", monospace;
+  font-size: 1.5rem;
+}


### PR DESCRIPTION
<img width="675" alt="screen shot 0029-11-11 at 16 04 29" src="https://user-images.githubusercontent.com/5661349/32693507-0f63982c-c6fa-11e7-8b75-6ea47cae4985.png">

Users now will enter a simple template string like `Doug 🎵 {{artist}} - {{track}}`.

You can use this as your upgrade script:

```sql
UPDATE settings SET twittertext = CONCAT(twittertext, ' {{artist}} — {{track}}');
```